### PR TITLE
Update @moq/boy and @moq/watch dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,12 +1,13 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "moq.dev",
       "dependencies": {
-        "@moq/boy": "^0.2.3",
+        "@moq/boy": "^0.2.5",
         "@moq/publish": "^0.2.4",
-        "@moq/watch": "^0.2.5",
+        "@moq/watch": "^0.2.7",
         "astro": "^5.18.1",
         "highlight.js": "^11.11.1",
         "solid-js": "^1.9.12",
@@ -242,7 +243,7 @@
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
-    "@moq/boy": ["@moq/boy@0.2.3", "", { "dependencies": { "@moq/lite": "^0.2.0", "@moq/signals": "^0.1.5", "@moq/ui-core": "^0.1.0", "@moq/watch": "^0.2.5", "zod": "^4.3.6" } }, "sha512-riMYCi5x9swsydcOjieBPqM2g9ix3kFoTXaFoMg+vPRFWHSiDK86vEFi2ITWdZ7SOmR4F4H1PWLCkG9dA0iY3w=="],
+    "@moq/boy": ["@moq/boy@0.2.5", "", { "dependencies": { "@moq/lite": "^0.2.0", "@moq/signals": "^0.1.5", "@moq/ui-core": "^0.1.0", "@moq/watch": "^0.2.7", "zod": "^4.3.6" } }, "sha512-QjbK7PpiUBcC4tey+2DjGvMuEGG12jdoKeUUwMZ0Zr8mr36FajmaSOfzRdFcw1S0PGzb/60S5aX/0SpqlD6y+Q=="],
 
     "@moq/hang": ["@moq/hang@0.2.2", "", { "dependencies": { "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5", "@libav.js/variant-opus-af": "^6.8.8", "@moq/lite": "^0.2.0", "@moq/signals": "^0.1.5", "@svta/cml-iso-bmff": "^1.0.0-alpha.9", "zod": "^4.1.5" } }, "sha512-Z1WVz4P7iIozN4ToKzSY/YzdCi8ilqT1u3oivgw+tDCRhRS4/QGMv25jU8+j5ZbpwX9JGvMRzg6/5oYfjupD3w=="],
 
@@ -256,7 +257,7 @@
 
     "@moq/ui-core": ["@moq/ui-core@0.1.0", "", { "peerDependencies": { "@moq/signals": "^0.1.2" } }, "sha512-DJNBpUNQDyh7Tou324fbJ5/pT08UPghH3OxcVdLEo9IQeX//8NiEzJwcX7iuacR32nzgdiBThIbIpeFa60U3/g=="],
 
-    "@moq/watch": ["@moq/watch@0.2.5", "", { "dependencies": { "@moq/hang": "^0.2.2", "@moq/lite": "^0.2.0", "@moq/signals": "^0.1.5", "@moq/ui-core": "^0.1.0" } }, "sha512-/THQIKkgz2mAKho2/bKZ3UTR41xd0wDdiv7qBYnj7LDlEKh5SHjtCs5fxgbfRs0Yisqn56ArH2nnQJe8vIcuzg=="],
+    "@moq/watch": ["@moq/watch@0.2.7", "", { "dependencies": { "@moq/hang": "^0.2.2", "@moq/lite": "^0.2.0", "@moq/signals": "^0.1.5", "@moq/ui-core": "^0.1.0" } }, "sha512-Uw49eiKfNJt+6fKgQzlk4GysAEfTGHH2G1AKCNJ7VnHgyJ7DlUIWGSjdN9uhRSCErhTmqixdV00SOKfOeP3D8A=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
 		"fix": "biome check --write && bun audit fix"
 	},
 	"dependencies": {
-		"@moq/boy": "^0.2.3",
+		"@moq/boy": "^0.2.5",
 		"@moq/publish": "^0.2.4",
-		"@moq/watch": "^0.2.5",
+		"@moq/watch": "^0.2.7",
 		"astro": "^5.18.1",
 		"highlight.js": "^11.11.1",
 		"solid-js": "^1.9.12",


### PR DESCRIPTION
## Summary
This PR updates two dependencies to their latest patch versions to incorporate bug fixes and improvements.

## Changes
- Bump `@moq/boy` from `^0.2.3` to `^0.2.5`
- Bump `@moq/watch` from `^0.2.5` to `^0.2.7`

## Details
These are minor version updates that bring in the latest fixes and improvements from the @moq package ecosystem. The lockfile has been updated to reflect the transitive dependency changes.

https://claude.ai/code/session_01QmetMdME2wym2Q5LdpAD2Y