### PR TITLE
Add latency disclaimer to moq-boy blog post

### DIFF
--- a/src/pages/blog/moq-boy.mdx
+++ b/src/pages/blog/moq-boy.mdx
@@ -16,9 +16,7 @@ Here's my MoQ copy of [Twitch Plays Pokemon](https://en.wikipedia.org/wiki/Twitc
 But there's a dilemma: I don't want to get sued by Nintendo.
 So enjoy homebrew games instead lul.
 
-The emulators are running on VMs in Texas, so don't flame me if the latency is high.
-
-And remember to scroll down and read the actual blog post once you're done **GAMING**.
+The emulators are running on VMs in Texas, so don't flame me if the latency is high. And remember to scroll down and read the actual blog post once you're done **GAMING**.
 
 <Boy />
 

--- a/src/pages/blog/moq-boy.mdx
+++ b/src/pages/blog/moq-boy.mdx
@@ -16,6 +16,8 @@ Here's my MoQ copy of [Twitch Plays Pokemon](https://en.wikipedia.org/wiki/Twitc
 But there's a dilemma: I don't want to get sued by Nintendo.
 So enjoy homebrew games instead lul.
 
+The emulators are running on VMs in Texas, so don't flame me if the latency is high.
+
 And remember to scroll down and read the actual blog post once you're done **GAMING**.
 
 <Boy />


### PR DESCRIPTION
## Summary
Added a clarifying note to the moq-boy blog post about emulator latency expectations.

## Changes
- Added a disclaimer explaining that the emulators are running on VMs hosted in Texas and setting expectations about potential latency issues

## Details
This is a minor documentation update to manage user expectations when interacting with the playable emulator demo. The note is positioned after the Nintendo disclaimer and before the call-to-action to read the full blog post.

https://claude.ai/code/session_016MsTwHS7qsbHHuuXi9U2fH