### PR TITLE
Append .hang suffix to broadcast names

### DIFF
--- a/src/components/publish-embed.tsx
+++ b/src/components/publish-embed.tsx
@@ -2,7 +2,7 @@ import { adjectives, animals, uniqueNamesGenerator } from "unique-names-generato
 import hljs from "@/lib/highlight";
 
 export default function PublishEmbed() {
-	const name = uniqueNamesGenerator({ dictionaries: [adjectives, animals], separator: "-" });
+	const name = `${uniqueNamesGenerator({ dictionaries: [adjectives, animals], separator: "-" })}.hang`;
 	const url = new URL("/anon", import.meta.env.PUBLIC_RELAY_URL);
 
 	const embedHtml = `<script type="module">

--- a/src/components/publish.tsx
+++ b/src/components/publish.tsx
@@ -7,7 +7,7 @@ import "@moq/publish/ui";
 import { Lite } from "@moq/publish";
 
 export default function Publish() {
-	const name = uniqueNamesGenerator({ dictionaries: [adjectives, animals], separator: "-" });
+	const name = `${uniqueNamesGenerator({ dictionaries: [adjectives, animals], separator: "-" })}.hang`;
 	const url = new URL("/anon", import.meta.env.PUBLIC_RELAY_URL);
 	const [copied, setCopied] = createSignal(false);
 

--- a/src/components/watch-embed.tsx
+++ b/src/components/watch-embed.tsx
@@ -2,7 +2,7 @@ import hljs from "@/lib/highlight";
 
 export default function WatchEmbed() {
 	const params = new URLSearchParams(window.location.search);
-	const name = params.get("name") ?? "bbb";
+	const name = params.get("name") ?? "bbb.hang";
 
 	// The relay URL on /watch may include a JWT for BBB; strip query params.
 	const relay = new URL("/anon", import.meta.env.PUBLIC_RELAY_URL);

--- a/src/components/watch.tsx
+++ b/src/components/watch.tsx
@@ -5,9 +5,9 @@ import { Lite } from "@moq/watch";
 
 export default function Watch() {
 	const params = new URLSearchParams(window.location.search);
-	const name = params.get("name") ?? "bbb";
+	const name = params.get("name") ?? "bbb.hang";
 
-	const url = new URL(name === "bbb" ? "/demo" : "/anon", import.meta.env.PUBLIC_RELAY_URL);
+	const url = new URL(name === "bbb.hang" ? "/demo" : "/anon", import.meta.env.PUBLIC_RELAY_URL);
 
 	return (
 		<>


### PR DESCRIPTION
Watch defaults to bbb.hang on the demo path; publish components
generate <adjective>-<animal>.hang names.

https://claude.ai/code/session_01LMRniVBb54fti5yCjTdhTv