### PR TITLE
Reorder demo cards: MoQ Boy first, then hang.live

### DIFF
--- a/src/pages/demo.mdx
+++ b/src/pages/demo.mdx
@@ -8,20 +8,6 @@ description: Live demos of the MoQ protocol in action.
 
 Click on any of them. That's what they're here for. Everything is open source!
 
-<a href="https://hang.live" rel="noreferrer" target="_blank" class="!text-white no-underline">
-	<article class="p-4 rounded-lg grid grid-cols-3 gap-4 items-center hover:bg-blue-950 hover:scale-105 hover:translate-x-2 transition-all ease-in-out">
-		<div class="flex justify-center">
-			<img src="/hang.svg" class="h-24" alt="hang.live" />
-		</div>
-		<div class="col-span-2 grid gap-2">
-			<div class="text-2xl">hang.live</div>
-			<div class="text-sm font-light">
-				A full-blown conferencing app built entirely on MoQ. Includes custom WebGL rendering, WebAudio panning, markdown chat, dank memes, you name it. You'll need a friend though, or at least another tab (I won't judge).
-			</div>
-		</div>
-	</article>
-</a>
-
 <a href="/boy" class="!text-white no-underline">
 	<article class="p-4 rounded-lg grid grid-cols-3 gap-4 items-center hover:bg-blue-950 hover:scale-105 hover:translate-x-2 transition-all ease-in-out">
 		<div class="flex justify-center">
@@ -31,6 +17,20 @@ Click on any of them. That's what they're here for. Everything is open source!
 			<div class="text-2xl">MoQ Boy</div>
 			<div class="text-sm font-light">
 				Multiplayer (anarchy) Game Boy emulation on a remote server, using MoQ tracks for everything. Emulation and encoding only run when at least one viewer is watching.
+			</div>
+		</div>
+	</article>
+</a>
+
+<a href="https://hang.live" rel="noreferrer" target="_blank" class="!text-white no-underline">
+	<article class="p-4 rounded-lg grid grid-cols-3 gap-4 items-center hover:bg-blue-950 hover:scale-105 hover:translate-x-2 transition-all ease-in-out">
+		<div class="flex justify-center">
+			<img src="/hang.svg" class="h-24" alt="hang.live" />
+		</div>
+		<div class="col-span-2 grid gap-2">
+			<div class="text-2xl">hang.live</div>
+			<div class="text-sm font-light">
+				A full-blown conferencing app built entirely on MoQ. Includes custom WebGL rendering, WebAudio panning, markdown chat, dank memes, you name it. You'll need a friend though, or at least another tab (I won't judge).
 			</div>
 		</div>
 	</article>


### PR DESCRIPTION
## Summary
Reordered the demo cards on the demo page to feature MoQ Boy as the primary demo, with hang.live as the secondary option.

## Changes
- Swapped the positions of the two demo cards in `src/pages/demo.mdx`
- MoQ Boy (Game Boy emulation) now appears first with link to `/boy`
- hang.live (conferencing app) now appears second with external link to `https://hang.live`
- Updated all associated metadata (images, alt text, descriptions) to match the new card positions

## Details
This change prioritizes the MoQ Boy demo as the featured example of MoQ protocol capabilities, positioning it before the hang.live conferencing application. The card content and styling remain unchanged; only their order in the page layout has been modified.

https://claude.ai/code/session_01961pFc42ao6gW8c6i8t1Eu