### PR TITLE
Bump @moq deps and switch from @moq/lite to @moq/net

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,9 @@
     "": {
       "name": "moq.dev",
       "dependencies": {
-        "@moq/boy": "^0.2.9",
-        "@moq/lite": "^0.2.4",
-        "@moq/publish": "^0.2.7",
-        "@moq/watch": "^0.2.11",
+        "@moq/boy": "^0.2.10",
+        "@moq/publish": "^0.2.8",
+        "@moq/watch": "^0.2.12",
         "astro": "^5.18.1",
         "highlight.js": "^11.11.1",
         "solid-js": "^1.9.12",
@@ -243,23 +242,25 @@
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
-    "@moq/boy": ["@moq/boy@0.2.9", "", { "dependencies": { "@moq/lite": "^0.2.3", "@moq/signals": "^0.1.6", "@moq/ui-core": "^0.1.1", "@moq/watch": "^0.2.11", "zod": "^4.3.6" } }, "sha512-o3RUgOrEd3uUOtJ5ole5RCYWxIrHjmvkmJJJ6D2vxLN0wsR1BBP7nkyxxO3AVGfZTVjZiquf+HJ73Ls4eQ3L0g=="],
+    "@moq/boy": ["@moq/boy@0.2.10", "", { "dependencies": { "@moq/net": "^0.1.1", "@moq/signals": "^0.1.6", "@moq/watch": "^0.2.12", "zod": "^4.3.6" } }, "sha512-dacdswZLDgWh8stsKDLoyBGOSy/5NlNiqbHgXT7GkHpCMqAYs2Y8FKl+eDlYl4NEHt3qpsfGsHV5KeyN0K2a/A=="],
 
-    "@moq/hang": ["@moq/hang@0.2.5", "", { "dependencies": { "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5", "@libav.js/variant-opus-af": "^6.8.8", "@moq/lite": "^0.2.3", "@moq/signals": "^0.1.6", "@svta/cml-iso-bmff": "^1.0.0-alpha.9", "zod": "^4.1.5" } }, "sha512-hDgVD9kCj8C5z0PAjTVDNnzQY94NqW8mzr15d6cWAmbqzga3WLYWx2yuUCgGmjVyIPZGujelbAnoRrA+Rqb+gA=="],
+    "@moq/hang": ["@moq/hang@0.2.6", "", { "dependencies": { "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5", "@libav.js/variant-opus-af": "^6.8.8", "@moq/loc": "^0.1.0", "@moq/net": "^0.1.1", "@moq/signals": "^0.1.6", "@svta/cml-iso-bmff": "^1.0.0-alpha.9", "zod": "^4.1.5" } }, "sha512-nTSd3BwfpMimsJb7AJAWscDsMmZN24qD6IjcLxyBZoOXtuAroVy/kvfWKjxUizlkMCKcryO5duH7VYdMQSKMdg=="],
 
-    "@moq/lite": ["@moq/lite@0.2.4", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.6", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-pd8AJl10EWjJYxy+rJJYlSJF+DFYudkMc1xkPtUUBzWCqiP9WD254oJo09xamu4ATXrDycg5IDRazqcvQTjZcg=="],
+    "@moq/lite": ["@moq/lite@0.2.3", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.6", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-hRoJPMcZNitN7dfbHSyxn6T8YRn1bm/lc72uNi5fFvRaF/g0HYdqPN/pG0W9QtXv2SG0kZagqX6L+gzcu3jYlw=="],
+
+    "@moq/loc": ["@moq/loc@0.1.0", "", { "dependencies": { "@moq/net": "^0.1.1" } }, "sha512-8ouPBhoZU/vAaHCrcsi97zOw0BJX/rQbfUJ7Dx2/Cmao6c4knrAXl8EVjlwKM4HLjfa8xzPd4Lqxkfv7G4QyhA=="],
 
     "@moq/msf": ["@moq/msf@0.1.0", "", { "dependencies": { "@moq/lite": "^0.2.1", "zod": "^4.1.5" } }, "sha512-5Y/RcxxofBXQSdy6IexzB8s2rpRI7xFiut1Zh6WO6hjNNqM+WKPPt+CTGKqnnnx/vhecgKrvpHnN228Zc0bakg=="],
 
-    "@moq/publish": ["@moq/publish@0.2.7", "", { "dependencies": { "@moq/hang": "^0.2.5", "@moq/lite": "^0.2.3", "@moq/signals": "^0.1.6", "@moq/ui-core": "^0.1.1" } }, "sha512-ViZjSNO4wVuochDb++GfxtE+YYwUtd+W8D5IwkhJ+0SfXr9ESj44Ubj8/fAH+tQplsiW29lF97mPG6/YmOStYA=="],
+    "@moq/net": ["@moq/net@0.1.1", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.6", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-HSyHlktvjt6hQoJYV2I9S7Ugcd6wdtQFwupIPFcYovNIEKCNiLEjSyhxPl/pETruJOu/y45CpNv29/4LN4gpag=="],
+
+    "@moq/publish": ["@moq/publish@0.2.8", "", { "dependencies": { "@moq/hang": "^0.2.6", "@moq/net": "^0.1.1", "@moq/signals": "^0.1.6" } }, "sha512-vzcRgkTYNYJLahBQNoAHWozD+0AvdlugP+VWEeDeKKK0m+vUtfQTWzZsbbk0O70oLJqzC59J7eomztU4kGS3YQ=="],
 
     "@moq/qmux": ["@moq/qmux@0.0.6", "", {}, "sha512-ISuGz05lUvf1hzHW3Aw3VnsGRJe1w9Qdog3LQ66KS+l+5mzQsPANvW8yOioEe1Z9dJO2G3sAHoGPnzwnsY9SIQ=="],
 
     "@moq/signals": ["@moq/signals@0.1.6", "", { "peerDependencies": { "@types/react": "^19.1.8", "react": "^19.0.0", "solid-js": "^1.9.7" }, "optionalPeers": ["@types/react", "react", "solid-js"] }, "sha512-ic7ttiz6dHXOPoVAfhz4K6LGT2LWdDGTi1x2u8sYSGZ5nOKGWfqDkwYcGvCPlcVQetn3PaeXYSPFiMAC6RO3tQ=="],
 
-    "@moq/ui-core": ["@moq/ui-core@0.1.1", "", { "peerDependencies": { "@moq/signals": "^0.1.6" } }, "sha512-a7L602/fiAnEba3VaCGKCawtVfrn2Ix91CaZiDd8x1PeO4KgNGtl3fu/oPuKM3K9jb1Jdj0s5VmXQJ3Q/e+r1Q=="],
-
-    "@moq/watch": ["@moq/watch@0.2.11", "", { "dependencies": { "@moq/hang": "^0.2.5", "@moq/lite": "^0.2.3", "@moq/msf": "^0.1.0", "@moq/signals": "^0.1.6", "@moq/ui-core": "^0.1.1" } }, "sha512-RYqzalMrNxVFVP3BdZmECDiqJZEgmOOe4sQEQFQt57gTiKorVDuv587gy/sfP8wrEfXZDgny47mTF5fMdjYsPQ=="],
+    "@moq/watch": ["@moq/watch@0.2.12", "", { "dependencies": { "@moq/hang": "^0.2.6", "@moq/msf": "^0.1.0", "@moq/net": "^0.1.1", "@moq/signals": "^0.1.6" } }, "sha512-BK0NlzlnSo34qNyvGKQwdCZMu8ZJfItbTmaQoFjQq2+y1xgG7IMnvi2MU9Qdsyc8QeKqzEd4xTjDPKoR1uJpLA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -1152,16 +1153,6 @@
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
-
-    "@moq/boy/@moq/lite": ["@moq/lite@0.2.3", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.6", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-hRoJPMcZNitN7dfbHSyxn6T8YRn1bm/lc72uNi5fFvRaF/g0HYdqPN/pG0W9QtXv2SG0kZagqX6L+gzcu3jYlw=="],
-
-    "@moq/hang/@moq/lite": ["@moq/lite@0.2.3", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.6", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-hRoJPMcZNitN7dfbHSyxn6T8YRn1bm/lc72uNi5fFvRaF/g0HYdqPN/pG0W9QtXv2SG0kZagqX6L+gzcu3jYlw=="],
-
-    "@moq/msf/@moq/lite": ["@moq/lite@0.2.3", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.6", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-hRoJPMcZNitN7dfbHSyxn6T8YRn1bm/lc72uNi5fFvRaF/g0HYdqPN/pG0W9QtXv2SG0kZagqX6L+gzcu3jYlw=="],
-
-    "@moq/publish/@moq/lite": ["@moq/lite@0.2.3", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.6", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-hRoJPMcZNitN7dfbHSyxn6T8YRn1bm/lc72uNi5fFvRaF/g0HYdqPN/pG0W9QtXv2SG0kZagqX6L+gzcu3jYlw=="],
-
-    "@moq/watch/@moq/lite": ["@moq/lite@0.2.3", "", { "dependencies": { "@moq/qmux": "^0.0.6", "@moq/signals": "^0.1.6", "async-mutex": "^0.5.0" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-hRoJPMcZNitN7dfbHSyxn6T8YRn1bm/lc72uNi5fFvRaF/g0HYdqPN/pG0W9QtXv2SG0kZagqX6L+gzcu3jYlw=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 

--- a/package.json
+++ b/package.json
@@ -13,10 +13,9 @@
 		"fix": "biome check --write && bun audit fix"
 	},
 	"dependencies": {
-		"@moq/boy": "^0.2.9",
-		"@moq/lite": "^0.2.4",
-		"@moq/publish": "^0.2.7",
-		"@moq/watch": "^0.2.11",
+		"@moq/boy": "^0.2.10",
+		"@moq/publish": "^0.2.8",
+		"@moq/watch": "^0.2.12",
 		"astro": "^5.18.1",
 		"highlight.js": "^11.11.1",
 		"solid-js": "^1.9.12",

--- a/src/components/watch-embed.tsx
+++ b/src/components/watch-embed.tsx
@@ -22,11 +22,10 @@ export default function WatchEmbed() {
     </moq-watch>
 </moq-watch-ui>`;
 
-	const embedJs = `import * as Moq from "@moq/lite";
-import * as Watch from "@moq/watch";
+	const embedJs = `import * as Watch from "@moq/watch";
 
 // A MoQ connection that is automatically re-established on drop.
-const connection = new Moq.Connection.Reload({
+const connection = new Watch.Lite.Connection.Reload({
     url: new URL("${publicUrl}"),
     enabled: true,
 });
@@ -35,7 +34,7 @@ const connection = new Moq.Connection.Reload({
 const broadcast = new Watch.Broadcast({
     connection: connection.established,
     enabled: true,
-    name: Moq.Path.from("${name}"),
+    name: Watch.Lite.Path.from("${name}"),
 });
 
 // Synchronize audio and video playback.

--- a/src/pages/boy.mdx
+++ b/src/pages/boy.mdx
@@ -17,7 +17,7 @@ Click a game to play. Multiple players can play at the same time; anarchy includ
 ## Features
 
 - 🦀 **Rust**: [moq-boy](https://doc.moq.dev/rs/crate/moq-boy) handles emulation and encoding. [moq-mux](https://doc.moq.dev/rs/crate/moq-mux) slurps in H.264/Opus bitstreams while [moq-lite](https://doc.moq.dev/rs/crate/moq-lite) handles the networking/caching.
-- 🌐 **Web**: [@moq/boy](https://doc.moq.dev/js/@moq/boy) is the browser player. [@moq/watch](https://doc.moq.dev/js/@moq/watch) handles decoding/rendering while [@moq/lite](https://doc.moq.dev/js/@moq/lite) handles the networking.
+- 🌐 **Web**: [@moq/boy](https://doc.moq.dev/js/@moq/boy) is the browser player. [@moq/watch](https://doc.moq.dev/js/@moq/watch) handles decoding/rendering while [@moq/net](https://doc.moq.dev/js/@moq/net) handles the networking.
 - 💤 **On-Demand**: Nothing is emulated or encoded until at least one viewer subscribes (per track). Saves you CPU and bandwidth!
 - 🧩 **Extensible**: Player controls and game status are sent as custom tracks (JSON in this case). You can do whatever you want!
 - 🌍 **Global CDN**: A generic MoQ CDN routes subscriptions over the backbone. Every client connects to the closest edge node to maximize QoS and minimize latency.

--- a/src/pages/source.mdx
+++ b/src/pages/source.mdx
@@ -40,7 +40,7 @@ Web code is written in [Typescript](https://github.com/moq-dev/moq/tree/main/js)
 
 | package | description |
 | ------- | ----------- |
-| [@moq/lite](https://www.npmjs.com/package/@moq/lite) | A moq-lite client that mirrors the Rust API. You can publish and subscribe to generic tracks. Any media stuff is implemented at a higher layer. |
+| [@moq/net](https://www.npmjs.com/package/@moq/net) | A moq-lite client that mirrors the Rust API. You can publish and subscribe to generic tracks. Any media stuff is implemented at a higher layer. |
 | [@moq/publish](https://www.npmjs.com/package/@moq/publish) | Publishing library with web components and UI. Provides `<moq-publish>` element and `<moq-publish-ui>` wrapper. |
 | [@moq/watch](https://www.npmjs.com/package/@moq/watch) | Watching library with web components and UI. Provides `<moq-watch>` element and `<moq-watch-ui>` wrapper. |
 


### PR DESCRIPTION
## Summary

- Update `@moq/boy` (0.2.9 → 0.2.10), `@moq/publish` (0.2.7 → 0.2.8), and `@moq/watch` (0.2.11 → 0.2.12) within their existing `^0.2` ranges.
- Drop the direct `@moq/lite` dependency. The networking package was renamed to `@moq/net` upstream; the embed snippet on `/watch` now imports only `@moq/watch` and reaches the networking API via the re-export (`Watch.Lite.Connection.Reload`, `Watch.Lite.Path`).
- Update doc references on `/boy` and `/source` to point at `@moq/net`.

## Why

Keeps us on current upstream releases, and using the re-export means the embed example matches a single import surface (`@moq/watch`) — one fewer package for embedders to add.

## Notes for reviewer

- `@moq/lite` 0.3.0 is published but is a major bump in 0.x semver; not taken here.
- The historical blog post `src/pages/blog/hash-tag-community.mdx` still references `@moq/lite` by design (point-in-time documentation).
- Deployed to staging (moq.wtf) and `just check` passes.

## Test plan

- [ ] `just check` passes locally
- [ ] Staging deploy on moq.wtf renders `/watch` and the embed code snippet correctly
- [ ] Embed code, when copy-pasted into a fresh page, still loads a broadcast

🤖 Generated with [Claude Code](https://claude.com/claude-code)