### PR TITLE
Move hang.live below Big Buck Bunny on demos page

### DIFF
--- a/src/pages/demo.mdx
+++ b/src/pages/demo.mdx
@@ -22,20 +22,6 @@ Click on any of them. That's what they're here for. Everything is open source!
 	</article>
 </a>
 
-<a href="https://hang.live" rel="noreferrer" target="_blank" class="!text-white no-underline">
-	<article class="p-4 rounded-lg grid grid-cols-3 gap-4 items-center hover:bg-blue-950 hover:scale-105 hover:translate-x-2 transition-all ease-in-out">
-		<div class="flex justify-center">
-			<img src="/hang.svg" class="h-24" alt="hang.live" />
-		</div>
-		<div class="col-span-2 grid gap-2">
-			<div class="text-2xl">hang.live</div>
-			<div class="text-sm font-light">
-				A full-blown conferencing app built entirely on MoQ. Includes custom WebGL rendering, WebAudio panning, markdown chat, dank memes, you name it. You'll need a friend though, or at least another tab (I won't judge).
-			</div>
-		</div>
-	</article>
-</a>
-
 <a href="/watch" class="!text-white no-underline">
 	<article class="p-4 rounded-lg grid grid-cols-3 gap-4 items-center hover:bg-blue-950 hover:scale-105 hover:translate-x-2 transition-all ease-in-out">
 		<div class="flex justify-center">
@@ -46,6 +32,20 @@ Click on any of them. That's what they're here for. Everything is open source!
 			<div class="text-sm font-light">
 				Watch a "live" broadcast of everybody's favorite rodent friend.
 				The video player is available as a (tree-shakable) Javascript library or <code>\<moq-watch\></code> web component.
+			</div>
+		</div>
+	</article>
+</a>
+
+<a href="https://hang.live" rel="noreferrer" target="_blank" class="!text-white no-underline">
+	<article class="p-4 rounded-lg grid grid-cols-3 gap-4 items-center hover:bg-blue-950 hover:scale-105 hover:translate-x-2 transition-all ease-in-out">
+		<div class="flex justify-center">
+			<img src="/hang.svg" class="h-24" alt="hang.live" />
+		</div>
+		<div class="col-span-2 grid gap-2">
+			<div class="text-2xl">hang.live</div>
+			<div class="text-sm font-light">
+				A full-blown conferencing app built entirely on MoQ. Includes custom WebGL rendering, WebAudio panning, markdown chat, dank memes, you name it. You'll need a friend though, or at least another tab (I won't judge).
 			</div>
 		</div>
 	</article>


### PR DESCRIPTION
Reorders the demo cards so hang.live appears below the Big Buck Bunny card.

New order: MoQ Boy → Big Buck Bunny → hang.live → Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)